### PR TITLE
Restore DNS hostname resolution for apt-proxy

### DIFF
--- a/auto-apt-proxy
+++ b/auto-apt-proxy
@@ -374,6 +374,7 @@ __detect__() {
 
   # Check for explicitly configured proxies
   detect_from v4_explicit_proxy_etc_hosts v6_explicit_proxy_etc_hosts && return 0
+  detect_from v4_explicit_proxy v6_explicit_proxy && return 0
   detect_DNS_SRV_record && return 0
   detect_avahi_local && return 0
 


### PR DESCRIPTION
Version 17 broke DNS-based hostname resolution for 'apt-proxy'. The code now only checks /etc/hosts statically and no longer performs DNS lookups, breaking portable laptop configurations that rely on DNS search domains.

This was inadvertently introduced in commit c2d0159 ("Check for explicitly configured proxies before trying the gateway") which refactored the detection flow but accidentally removed the DNS-resolving functions v4_explicit_proxy() and v6_explicit_proxy() from the detection sequence.

This fix restores DNS hostname resolution by adding back the calls to v4_explicit_proxy and v6_explicit_proxy, while preserving the intent of c2d0159 to check explicit proxies before the gateway.

The detection order is now:
1. Local running proxies (localhost, local addresses)
2. Container host
3. Explicitly configured proxies via /etc/hosts
4. Explicitly configured proxies via DNS hostname resolution (restored)
5. DNS SRV records
6. Avahi/mDNS
7. Network gateway

This allows users with DNS search domains (e.g., 'search example.com' in /etc/resolv.conf) to resolve 'apt-proxy' via DNS again, enabling portable configurations that gracefully handle being away from the home network.